### PR TITLE
Update http-echo pod version. Tweak resources

### DIFF
--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: echoserver
     spec:
       containers:
-      - image: hashicorp/http-echo:0.2.3
+      - image: hashicorp/http-echo:1.0.0
         imagePullPolicy: Always
         name: echoserver
         command:
@@ -29,3 +29,10 @@ spec:
         - "-text=foo"
         ports:
         - containerPort: 8080
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi

--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -7,7 +7,14 @@ metadata:
 spec:
   containers:
   - name: foo-app
-    image: hashicorp/http-echo:0.2.3
+    image: hashicorp/http-echo:1.0.0
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 200m
+        memory: 200Mi
     args:
     - "-listen=0.0.0.0:8080"
     - "-text=foo"

--- a/examples/replicaset.yaml
+++ b/examples/replicaset.yaml
@@ -18,7 +18,7 @@ spec:
         app: echoserver
     spec:
       containers:
-      - image: hashicorp/http-echo:0.2.3
+      - image: hashicorp/http-echo:1.0.0
         imagePullPolicy: IfNotPresent
         name: echoserver
         args:


### PR DESCRIPTION
Changes
- Update version of http-echo
- Add resource limits/requests to avoid linter warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application to use the latest version (`1.0.0`) of the `hashicorp/http-echo` service for enhanced performance and features.
	- Implemented resource management by setting requests and limits for CPU and memory to improve application stability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->